### PR TITLE
Added Output for Total Power Consumed

### DIFF
--- a/jtop/gui/jtopguimenu.py
+++ b/jtop/gui/jtopguimenu.py
@@ -78,11 +78,19 @@ def plot_temperatures(stdscr, start, offset, width, jetson):
 def plot_voltages(stdscr, start, offset, width, jetson):
     # Plot title
     stdscr.addstr(offset, start, "{name:<12} [Cur]   [Avr]".format(name="[Power/mW]"), curses.A_BOLD)
+    #Add Variable to keep track of total
+    total_avg = 0
+    total_cur = 0
     # Plot voltages
     for idx, volt in enumerate(sorted(jetson.stats['VOLT'])):
         value = jetson.stats['VOLT'][volt]
+        total_cur += int(value['cur'])
+        total_avg += int(value['avg'])
         stdscr.addstr(offset + idx + 1, start,
                       ("{name:<12} {curr: <7} {avg: <7}").format(name=volt, curr=int(value['cur']), avg=int(value['avg'])))
+    # plot totals before finishing    
+    stdscr.addstr(offset + idx + 1, start,
+                      ("{name:<12} {curr: <7} {avg: <7}").format(name="Total", curr=total_cur, avg=total_avg))
 
 
 @check_curses


### PR DESCRIPTION
This change will have JTOP display the total power currently being used, and on average as defined by the values from Tegra stats. I added variables to keep track of the power consumed. It totals the power, both average and current, given from the Tegra stats, and then prints them below the other power stats.